### PR TITLE
Ember 2.0 Update (and other fixes)

### DIFF
--- a/app/components/bs-accordion-item.js
+++ b/app/components/bs-accordion-item.js
@@ -1,4 +1,4 @@
 import Ember from 'ember';
-import component from 'ember-bootstrap/components/bs-accordion-item';
+import component from 'ember-bootstrap-components/components/bs-accordion-item';
 
 export default component;

--- a/app/components/bs-accordion.js
+++ b/app/components/bs-accordion.js
@@ -1,4 +1,4 @@
 import Ember from 'ember';
-import component from 'ember-bootstrap/components/bs-accordion';
+import component from 'ember-bootstrap-components/components/bs-accordion';
 
 export default component;

--- a/app/components/bs-collapse.js
+++ b/app/components/bs-collapse.js
@@ -1,4 +1,4 @@
 import Ember from 'ember';
-import component from 'ember-bootstrap/components/bs-collapse';
+import component from 'ember-bootstrap-components/components/bs-collapse';
 
 export default component;

--- a/app/helpers/is-equal.js
+++ b/app/helpers/is-equal.js
@@ -1,1 +1,1 @@
-export { default, isEqual } from 'ember-bootstrap/helpers/is-equal';
+export { default, isEqual } from 'ember-bootstrap-components/helpers/is-equal';

--- a/app/helpers/is-not.js
+++ b/app/helpers/is-not.js
@@ -1,1 +1,1 @@
-export { default, isNot } from 'ember-bootstrap/helpers/is-not';
+export { default, isNot } from 'ember-bootstrap-components/helpers/is-not';

--- a/app/helpers/read-path.js
+++ b/app/helpers/read-path.js
@@ -1,1 +1,1 @@
-export { default, readPath } from 'ember-bootstrap/helpers/read-path';
+export { default, readPath } from 'ember-bootstrap-components/helpers/read-path';

--- a/app/initializers/register-modal.js
+++ b/app/initializers/register-modal.js
@@ -3,9 +3,9 @@ import instanceInitializer from "../instance-initializers/register-modal";
 export default {
   name: instanceInitializer.name,
 
-  initialize: function(registry, application) {
-    if (application.instanceInitializer) { return; }
+  initialize: function(App) {
+    if (App.instanceInitializer) { return; }
 
-    instanceInitializer.initialize(application);
+    instanceInitializer.initialize(App);
   }
 };

--- a/app/instance-initializers/register-modal.js
+++ b/app/instance-initializers/register-modal.js
@@ -2,6 +2,6 @@ export default {
   name: 'register-modal',
   initialize: function(instance) {
 	window.Bootstrap = {};
-	window.Bootstrap.ModalManager = instance.container.lookup("service:bootstrap-modal-manager");
+	window.Bootstrap.ModalManager = instance.lookup("service:bootstrap-modal-manager");
   }
 };

--- a/tests/unit/mixins/component-child-test.js
+++ b/tests/unit/mixins/component-child-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import ComponentChildMixin from 'ember-bootstrap/mixins/component-child';
-import ComponentParentMixin from 'ember-bootstrap/mixins/component-parent';
+import ComponentChildMixin from 'ember-bootstrap-components/mixins/component-child';
+import ComponentParentMixin from 'ember-bootstrap-components/mixins/component-parent';
 
 import { module, test } from 'qunit';
 

--- a/tests/unit/mixins/component-parent-test.js
+++ b/tests/unit/mixins/component-parent-test.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ComponentParentMixin from 'ember-bootstrap/mixins/component-parent';
+import ComponentParentMixin from 'ember-bootstrap-components/mixins/component-parent';
 import { module, test } from 'qunit';
 
 module('Unit | Mixin | component parent');


### PR DESCRIPTION
Just some simple changed needed to remove deprecation warnings for Ember 2.0
Also, updated some paths that were causing errors.

Still need to look at the "Unsafe class name binding" deprecations.

Feedback welcome.
